### PR TITLE
Mise à jour de la version recommandée pour XWiki

### DIFF
--- a/2020/sill-2020.csv
+++ b/2020/sill-2020.csv
@@ -211,4 +211,4 @@ ID,nom,fonction,annees,statut,parent,public,similaire-a,wikidata,comptoir-du-lib
 211,SPIP,Système de gestion de contenus web,2020,R,,,36 ; 162 ; 173 ; 203,,,GPL-3.0,Données et contenu,Gestion de contenu web,,MIMO,3.2.7
 212,Pentaho CE,Plateforme BI,2020,O,,,,Q644841,,"GPL-2.0, LGPL-2, MPL-1.1",Opérations,Outil métier,,MIMO,
 213,Tracim,Outil de gestion des connaissances,2020,R,,,,,,"MIT, LGPL-3, AGPL-3",Données et contenu,Gestion de contenu web,,MIMO,
-214,XWiki,Moteur de wiki,2020,R,,,86,Q526699,,LGPL-2.1,Orchestration et logique métier,Outil collaboratif,,MIMO,10.11.3
+214,XWiki,Moteur de wiki,2020,R,,,86,Q526699,,LGPL-2.1,Orchestration et logique métier,Outil collaboratif,,MIMO,11.10.5


### PR DESCRIPTION
La dernière version stable et maintenue de XWiki est la version 11.10.5 (cf https://www.xwiki.org/xwiki/bin/view/Download/).