### PR TITLE
Ajout de l'ID comptoir pour 10 logiciels (SILL-2020)

### DIFF
--- a/2020/sill-2020.csv
+++ b/2020/sill-2020.csv
@@ -24,7 +24,7 @@ ID,nom,fonction,annees,statut,parent,public,similaire-a,wikidata,comptoir-du-lib
 23,ClamAV,Antivirus : Orienté serveur,2018 ; 2019 ; 2020,R,,,,Q852000,211,GPL-2.0-only,Sécurité,Antivirus,Serveur Bureautique,MIMPROD,Distribution
 24,CockroachDB,Base transactionnelle cluster,2019 ; 2020,O,,,,,303,,Données et contenu,BD Relationnelles,Base de production,MIMPROD,2
 25,CodeceptJS,Framework de tests backend,2019 ; 2020,O,,,,,306,MIT,Conception & Développement,Test & Intégration,,MIMDEV,2.4.1
-26,Consul,Déploiement,2018 ; 2019 ; 2020,O,,,,Q28709844,,MPL-2.0,Opérations,Outils système & virtualisation,Services déconcentrés,MIMPROD,Distribution
+26,Consul,Déploiement,2018 ; 2019 ; 2020,O,,,,Q28709844,226,MPL-2.0,Opérations,Outils système & virtualisation,Services déconcentrés,MIMPROD,Distribution
 27,Corosync,Haute Disponibilté,2018 ; 2019 ; 2020,R,,,,,235,BSD-3-Clause,Logiciel Système et Virtualisation,Haute disponibilité (OS),Infra virtuelle,MIMPROD,Distribution
 28,CUPS,Serveur d'impression,2018 ; 2019 ; 2020,R,,,,Q868171,217,,Intégration & Échanges,Serveur d'impression,Services déconcentrés,MIMPROD,Distribution
 29,Data Injection,Injection de données dans GLPI à l'aide de fichiers CSV,2018 ; 2019 ; 2020,R,GLPI,,,,92,GPL-2.0-only,Opérations,Déploiement gestion d’actif et de configuration,,MIMO,2.6.4
@@ -202,13 +202,13 @@ ID,nom,fonction,annees,statut,parent,public,similaire-a,wikidata,comptoir-du-lib
 202,Zimbra,Outil de webmail,2020,R,,,171 ; 68,Q203485,110,Zimbra-1.3,Espace utilisateur et canal,Messagerie agenda contacts,"**Attention** : à partir de la version 9, [Zimbra ne sera plus sous licence libre](https://wiki.zimbra.com/wiki/Zimbra_Releases/9.0.0)",MIMPROD,> 8 et < 9
 203,TYPO3,Système de gestion de contenus web,2020,R,,,36 ; 162 ; 173 ; 211,Q618512,87,"GPL-2.0, LGPL-3.0",Données et contenu,Gestion de contenu web,,MIMO,9.5.16
 204,Color Contrast Analyser,Outil d'analyse de contraste des couleurs,2020,R,,,,,,GPL-3.0,Conception & Développement,Environnement de développement,,MIMO,
-205,Démarches simplifiées,Outil de gestion de formulaires en ligne,2020,R,,Oui,,Q93597458,,AGPL-3.0,Opérations,Outil métier,Déployée à la DINUM sur https://www.demarches-simplifiees.fr,MIMO,2020-06-23-02
-206,FusionDirectory,Outil de gestion d'identités,2020,R,,,,,,GPL-2.0,Sécurité,Authentification,,MIMPROD,1.3
-207,JOSM,Outil d'édition d'OpenStreetMap,2020,R,,,,Q12877,,GPL-2.0+,Espace utilisateur et canal,Outil de productivité,,MIMO,16538
-208,Moodle,Plateforme d'apprentissage à distance,2020,R,,,209,Q190434,,GPL-3.0,Données et contenu,Gestion de contenu web,,MIMO,3.9
-209,Open EDX,Plateforme d'apprentissage à distance,2020,R,,,208,Q2106448,,AGPL-3.0,Données et contenu,Gestion de contenu web,,MIMO,
-210,Esup-Pod,Plateforme de gestion de fichiers vidéo,2020,R,,,197,,,LGPL-3.0,Données et contenu,Gestion de contenu web,,MIMO,2.6.0
+205,Démarches simplifiées,Outil de gestion de formulaires en ligne,2020,R,,Oui,,Q93597458,136,AGPL-3.0,Opérations,Outil métier,Déployée à la DINUM sur https://www.demarches-simplifiees.fr,MIMO,2020-06-23-02
+206,FusionDirectory,Outil de gestion d'identités,2020,R,,,,,46,GPL-2.0,Sécurité,Authentification,,MIMPROD,1.3
+207,JOSM,Outil d'édition d'OpenStreetMap,2020,R,,,,Q12877,390,GPL-2.0+,Espace utilisateur et canal,Outil de productivité,,MIMO,16538
+208,Moodle,Plateforme d'apprentissage à distance,2020,R,,,209,Q190434,250,GPL-3.0,Données et contenu,Gestion de contenu web,,MIMO,3.9
+209,Open EDX,Plateforme d'apprentissage à distance,2020,R,,,208,Q2106448,396,AGPL-3.0,Données et contenu,Gestion de contenu web,,MIMO,
+210,Esup-Pod,Plateforme de gestion de fichiers vidéo,2020,R,,,197,,397,LGPL-3.0,Données et contenu,Gestion de contenu web,,MIMO,2.6.0
 211,SPIP,Système de gestion de contenus web,2020,R,,,36 ; 162 ; 173 ; 203,Q1536426,36,GPL-3.0,Données et contenu,Gestion de contenu web,,MIMO,3.2.7
-212,Pentaho CE,Plateforme BI,2020,O,,,,Q644841,,"GPL-2.0, LGPL-2, MPL-1.1",Opérations,Outil métier,,MIMO,
-213,Tracim,Outil de gestion des connaissances,2020,R,,,,,,"MIT, LGPL-3, AGPL-3",Données et contenu,Gestion de contenu web,,MIMO,
-214,XWiki,Moteur de wiki,2020,R,,,86,Q526699,,LGPL-2.1,Orchestration et logique métier,Outil collaboratif,,MIMO,10.11.3
+212,Pentaho CE,Plateforme BI,2020,O,,,,Q644841,105,"GPL-2.0, LGPL-2, MPL-1.1",Opérations,Outil métier,,MIMO,
+213,Tracim,Outil de gestion des connaissances,2020,R,,,,,273,"MIT, LGPL-3, AGPL-3",Données et contenu,Gestion de contenu web,,MIMO,
+214,XWiki,Moteur de wiki,2020,R,,,86,Q526699,11,LGPL-2.1,Orchestration et logique métier,Outil collaboratif,,MIMO,10.11.3


### PR DESCRIPTION
Ajout de l'ID comptoir pour 10 logiciels (SILL-2020) : 
- Consul : voir #109 ---> https://comptoir-du-libre.org/fr/softwares/226
- Démarches simplifiées ---> https://comptoir-du-libre.org/fr/softwares/136
- FusionDirectory ---> https://comptoir-du-libre.org/fr/softwares/46
- JOSM ---> https://comptoir-du-libre.org/fr/softwares/390
- Moodle ---> https://comptoir-du-libre.org/fr/softwares/250
- Open EDX ---> https://comptoir-du-libre.org/fr/softwares/396
- Esup-Pod ---> https://comptoir-du-libre.org/fr/softwares/397
- Pentaho CE ---> https://comptoir-du-libre.org/fr/softwares/105
- Tracim ---> https://comptoir-du-libre.org/fr/softwares/273
- XWiki ---> https://comptoir-du-libre.org/fr/softwares/11